### PR TITLE
Use default format for nginx (Common Log format)

### DIFF
--- a/rails-logs/templates/default/cwlogs.cfg.erb
+++ b/rails-logs/templates/default/cwlogs.cfg.erb
@@ -10,7 +10,7 @@ file = <%= node[:cwlogs][:railslogfile] %>
 log_stream_name = <%= node[:opsworks][:instance][:hostname] %>
 
 [<%= node[:opsworks][:stack][:name] %>_nginx]
-datetime_format = [%Y-%m-%d %H:%M:%S]
+datetime_format = [%d/%b/%Y:%H:%M:%S %z]
 log_group_name = <%= node[:opsworks][:stack][:name].gsub(' ','_') %>_nginx
 file = <%= node[:cwlogs][:nginxaccessfile] %>
 log_stream_name = <%= node[:opsworks][:instance][:hostname] %>


### PR DESCRIPTION
This PR fixes the date parsing for nginx's access log.

According to [nginx documentation](http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format) the default format for its access log is:

```
log_format combined '$remote_addr - $remote_user [$time_local] '
                    '"$request" $status $body_bytes_sent '
                    '"$http_referer" "$http_user_agent"';
```

Where `$time_local` is the _local time in the Common Log Format_. According to [Wikipedia](http://en.wikipedia.org/wiki/Common_Log_Format) this mean the format is `%d/%b/%Y:%H:%M:%S %z`.
